### PR TITLE
Add Spotify refresh token script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cypress/screenshots
 cypress/video
 .vercel
 .env*.local
+.worktrees

--- a/docs/plans/2026-02-15-spotify-refresh-token-tool-design.md
+++ b/docs/plans/2026-02-15-spotify-refresh-token-tool-design.md
@@ -1,0 +1,37 @@
+# Spotify Refresh Token Tool
+
+## Problem
+
+The project needs a `SPOTIFY_USER_REFRESH_TOKEN` for playlist management. There's no tooling to obtain one via Spotify's OAuth Authorization Code flow. Currently you'd have to do this manually via curl/Postman.
+
+## Design
+
+A single TypeScript script (`scripts/get-spotify-refresh-token.ts`) that automates the Spotify Authorization Code flow locally.
+
+### Flow
+
+1. Reads `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` from environment (`.env.local`)
+2. Starts a temporary HTTP server on `localhost:8888`
+3. Opens the browser to Spotify's `/authorize` endpoint with scope `playlist-modify-public` and redirect URI `http://localhost:8888/callback`
+4. User logs in and approves in the browser
+5. Spotify redirects to localhost with an authorization `code`
+6. Script exchanges the code for tokens at `accounts.spotify.com/api/token`
+7. Prints the refresh token, shuts down the server
+
+### Dependencies
+
+None new. Uses Node built-ins (`http`, `url`, `crypto`, `child_process`). Run with `npx tsx`.
+
+### Package.json
+
+Add script: `"get-spotify-token": "tsx scripts/get-spotify-refresh-token.ts"`
+
+### Spotify App Setup
+
+Add `http://localhost:8888/callback` as a redirect URI in the Spotify app dashboard (one-time).
+
+## Decisions
+
+- No third-party packages — the OAuth flow is ~50 lines and avoids trusting external code with credentials
+- Reads env vars from `.env.local` for convenience (same file the project already uses)
+- Prints token to stdout rather than writing to a file — user copies it to Vercel env vars manually

--- a/docs/plans/2026-02-15-spotify-refresh-token-tool-plan.md
+++ b/docs/plans/2026-02-15-spotify-refresh-token-tool-plan.md
@@ -1,0 +1,206 @@
+# Spotify Refresh Token Tool Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a local script that runs Spotify's Authorization Code flow and prints a refresh token.
+
+**Architecture:** Single TypeScript script using Node built-ins (`http`, `url`, `crypto`, `child_process`). Loads env vars from `.env.local` via `dotenv` (already a devDependency). No new dependencies.
+
+**Tech Stack:** TypeScript, Node.js built-ins, dotenv
+
+---
+
+### Task 1: Create the refresh token script
+
+**Files:**
+- Create: `scripts/get-spotify-refresh-token.ts`
+
+**Step 1: Create the script**
+
+Create `scripts/get-spotify-refresh-token.ts` with the following:
+
+```typescript
+import 'dotenv/config';
+import http from 'http';
+import { URL } from 'url';
+import crypto from 'crypto';
+import { exec } from 'child_process';
+
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+const PORT = 8888;
+const REDIRECT_URI = `http://localhost:${PORT}/callback`;
+const SCOPES = 'playlist-modify-public';
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error(
+    'Missing SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET.\n' +
+      'Set them in .env.local or as environment variables.'
+  );
+  process.exit(1);
+}
+
+const state = crypto.randomBytes(16).toString('hex');
+
+const authorizeUrl =
+  'https://accounts.spotify.com/authorize?' +
+  new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+    redirect_uri: REDIRECT_URI,
+    state,
+  }).toString();
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url!, `http://localhost:${PORT}`);
+
+  if (url.pathname !== '/callback') {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  const code = url.searchParams.get('code');
+  const returnedState = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Authorization denied. You can close this window.');
+    console.error(`Authorization error: ${error}`);
+    server.close();
+    return;
+  }
+
+  if (returnedState !== state) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('State mismatch. You can close this window.');
+    console.error('State mismatch — possible CSRF attack.');
+    server.close();
+    return;
+  }
+
+  if (!code) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('No code received. You can close this window.');
+    console.error('No authorization code received.');
+    server.close();
+    return;
+  }
+
+  // Exchange the code for tokens
+  const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64'),
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+    }).toString(),
+  });
+
+  const data = await tokenResponse.json();
+
+  if (!tokenResponse.ok) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Token exchange failed. Check your terminal.');
+    console.error('Token exchange failed:', data);
+    server.close();
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Got your refresh token! You can close this window.');
+
+  console.log('\n✅ Success!\n');
+  console.log('Refresh token:');
+  console.log(data.refresh_token);
+  console.log('\nSet this as SPOTIFY_USER_REFRESH_TOKEN in your Vercel environment variables.');
+
+  server.close();
+});
+
+server.listen(PORT, () => {
+  console.log(`Listening on http://localhost:${PORT}`);
+  console.log('Opening Spotify authorization page in your browser...\n');
+
+  // Open browser (macOS)
+  exec(`open "${authorizeUrl}"`);
+});
+```
+
+**Step 2: Run the script to verify it starts**
+
+Run: `npx tsx scripts/get-spotify-refresh-token.ts`
+
+Expected: Script prints "Listening on http://localhost:8888" and opens browser. Ctrl+C to stop.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/get-spotify-refresh-token.ts
+git commit -m "feat: add Spotify refresh token script"
+```
+
+---
+
+### Task 2: Add package.json script
+
+**Files:**
+- Modify: `package.json` (scripts section)
+
+**Step 1: Add the script entry**
+
+Add to the `scripts` section in `package.json`:
+
+```json
+"get-spotify-token": "npx tsx scripts/get-spotify-refresh-token.ts"
+```
+
+**Step 2: Verify it runs**
+
+Run: `yarn get-spotify-token`
+
+Expected: Same behavior as running with npx tsx directly.
+
+**Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "feat: add get-spotify-token script to package.json"
+```
+
+---
+
+### Task 3: Load dotenv from .env.local specifically
+
+**Files:**
+- Modify: `scripts/get-spotify-refresh-token.ts` (line 1)
+
+**Step 1: Update dotenv import to target .env.local**
+
+The default `dotenv/config` loads `.env`, but this project uses `.env.local`. Change the import at the top of the script:
+
+```typescript
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.local' });
+```
+
+Replace the `import 'dotenv/config';` line.
+
+**Step 2: Verify**
+
+Run: `yarn get-spotify-token`
+
+Expected: If `.env.local` exists with Spotify creds, the script starts normally. If not, prints the missing env var error.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/get-spotify-refresh-token.ts
+git commit -m "fix: load dotenv from .env.local"
+```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "test:backend": "vitest run",
-    "test:backend:watch": "vitest"
+    "test:backend:watch": "vitest",
+    "get-spotify-token": "npx tsx scripts/get-spotify-refresh-token.ts"
   },
   "prettier": {
     "jsxSingleQuote": true,

--- a/scripts/get-spotify-refresh-token.ts
+++ b/scripts/get-spotify-refresh-token.ts
@@ -1,0 +1,112 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.local' });
+import http from 'http';
+import { URL } from 'url';
+import crypto from 'crypto';
+import { exec } from 'child_process';
+
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+const PORT = 8888;
+const REDIRECT_URI = `http://localhost:${PORT}/callback`;
+const SCOPES = 'playlist-modify-public';
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error(
+    'Missing SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET.\n' +
+      'Set them in .env.local or as environment variables.'
+  );
+  process.exit(1);
+}
+
+const state = crypto.randomBytes(16).toString('hex');
+
+const authorizeUrl =
+  'https://accounts.spotify.com/authorize?' +
+  new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+    redirect_uri: REDIRECT_URI,
+    state,
+  }).toString();
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url!, `http://localhost:${PORT}`);
+
+  if (url.pathname !== '/callback') {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  const code = url.searchParams.get('code');
+  const returnedState = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Authorization denied. You can close this window.');
+    console.error(`Authorization error: ${error}`);
+    server.close();
+    return;
+  }
+
+  if (returnedState !== state) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('State mismatch. You can close this window.');
+    console.error('State mismatch — possible CSRF attack.');
+    server.close();
+    return;
+  }
+
+  if (!code) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('No code received. You can close this window.');
+    console.error('No authorization code received.');
+    server.close();
+    return;
+  }
+
+  // Exchange the code for tokens
+  const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64'),
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+    }).toString(),
+  });
+
+  const data = await tokenResponse.json();
+
+  if (!tokenResponse.ok) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Token exchange failed. Check your terminal.');
+    console.error('Token exchange failed:', data);
+    server.close();
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Got your refresh token! You can close this window.');
+
+  console.log('\nSuccess!\n');
+  console.log('Refresh token:');
+  console.log(data.refresh_token);
+  console.log('\nSet this as SPOTIFY_USER_REFRESH_TOKEN in your Vercel environment variables.');
+
+  server.close();
+});
+
+server.listen(PORT, () => {
+  console.log(`Listening on http://localhost:${PORT}`);
+  console.log('Opening Spotify authorization page in your browser...\n');
+
+  // Open browser (macOS)
+  exec(`open "${authorizeUrl}"`);
+});

--- a/scripts/get-spotify-refresh-token.ts
+++ b/scripts/get-spotify-refresh-token.ts
@@ -7,8 +7,8 @@ import { exec } from 'child_process';
 
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
-const PORT = 8888;
-const REDIRECT_URI = `http://localhost:${PORT}/callback`;
+const PORT = 3000;
+const REDIRECT_URI = `http://127.0.0.1:${PORT}`;
 const SCOPES = 'playlist-modify-public';
 
 if (!CLIENT_ID || !CLIENT_SECRET) {
@@ -32,13 +32,7 @@ const authorizeUrl =
   }).toString();
 
 const server = http.createServer(async (req, res) => {
-  const url = new URL(req.url!, `http://localhost:${PORT}`);
-
-  if (url.pathname !== '/callback') {
-    res.writeHead(404);
-    res.end();
-    return;
-  }
+  const url = new URL(req.url!, `http://127.0.0.1:${PORT}`);
 
   const code = url.searchParams.get('code');
   const returnedState = url.searchParams.get('state');
@@ -104,7 +98,7 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.listen(PORT, () => {
-  console.log(`Listening on http://localhost:${PORT}`);
+  console.log(`Listening on http://127.0.0.1:${PORT}`);
   console.log('Opening Spotify authorization page in your browser...\n');
 
   // Open browser (macOS)


### PR DESCRIPTION
## Summary
- Adds a local dev utility (`scripts/get-spotify-refresh-token.ts`) that runs Spotify's OAuth Authorization Code flow to obtain a refresh token
- Uses Node built-ins only (no new dependencies) — reads credentials from `.env.local`, spins up a temp server on `http://127.0.0.1:3000`, opens browser, exchanges auth code for tokens, prints refresh token
- Adds `yarn get-spotify-token` script for easy invocation

## Test plan
- [x] Script starts and opens browser when credentials are present
- [x] OAuth flow completes and refresh token is returned
- [x] Token has `playlist-modify-public` scope (verified via token exchange)
- [x] Script exits with helpful error when credentials are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)